### PR TITLE
Add support for TLS 1.2

### DIFF
--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Owin;
+﻿using System.Net;
+using Microsoft.Owin;
 using Owin;
 [assembly: OwinStartup(typeof(Web.Startup))]
 namespace Web
@@ -7,7 +8,19 @@ namespace Web
 	{
 		public void Configuration(IAppBuilder app)
 		{
+			AllowBetterCrypto();
+
 			app.MapSignalR();
+		}
+
+		private static void AllowBetterCrypto()
+		{
+			// by default TLS 1.1 and 1.2 are not enabled
+			ServicePointManager.SecurityProtocol =
+				SecurityProtocolType.Ssl3 |
+				SecurityProtocolType.Tls |
+				SecurityProtocolType.Tls11 |
+				SecurityProtocolType.Tls12;
 		}
 	}
 }


### PR DESCRIPTION
Adds support for TLS 1.2 as required by the Pushpay API

- Sandbox API access will require TLS 1.2 from May 2018 onwards.
- Production API access will require TLS 1.2 from June 30th onwards.